### PR TITLE
[ENH] Install requirements in setup.py + add makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+# simple makefile to simplify repetetive build env management tasks under posix
+
+PYTHON ?= python
+CYTHON ?= cython
+PYTESTS ?= pytest
+
+CTAGS ?= ctags
+
+all: clean inplace test
+
+clean-pyc:
+	find . -name "*.pyc" | xargs rm -f
+	find . -name "__pycache__" | xargs rm -rf
+
+clean-so:
+	find . -name "*.so" | xargs rm -f
+	find . -name "*.pyd" | xargs rm -f
+	find . -name "*.cpp" | xargs rm -f
+
+clean-build:
+	rm -rf build
+
+clean-ctags:
+	rm -f tags
+
+clean: clean-build clean-pyc clean-so clean-ctags
+
+in: inplace # just a shortcut
+inplace:
+	$(PYTHON) setup.py build_ext -i
+
+test-code:
+	$(PYTESTS) gsroptim
+
+test-doc:
+	$(PYTESTS) $(shell find doc -name '*.rst' | sort)
+
+test-coverage:
+	rm -rf coverage .coverage
+	$(PYTESTS) gsroptim --cov=gsroptim --cov-report html:coverage
+
+test: test-code test-doc test-manifest
+
+trailing-spaces:
+	find . -name "*.py" | xargs perl -pi -e 's/[ \t]*$$//'
+
+cython:
+	find -name "*.pyx" | xargs $(CYTHON)
+
+ctags:
+	# make tags for symbol based navigation in emacs and vim
+	# Install with: sudo apt-get install exuberant-ctags
+	$(CTAGS) -R *
+
+.PHONY : doc-plot
+doc-plot:
+	make -C doc html
+
+.PHONY : doc
+doc:
+	make -C doc html-noplot
+
+test-manifest:
+	check-manifest --ignore doc,gsroptim/*/tests;

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
+import glob
+from setuptools import dist, setup, Extension
+from setuptools.command.build_ext import build_ext
+dist.Distribution().fetch_build_eggs(['numpy>=1.12'])
 import numpy as np
-from distutils.core import setup
-from Cython.Build import cythonize
+
 
 DISTNAME = 'gsroptim'
 DESCRIPTION = 'Fast coordinate descent solver with Gap Safe screening Rules'
@@ -12,6 +15,13 @@ DOWNLOAD_URL = 'https://github.com/EugeneNdiaye/Gap_Safe_Rules.git'
 URL = 'https://github.com/EugeneNdiaye/Gap_Safe_Rules.git'
 VERSION = None
 
+
+# TODO using language='c++' break so far bc of a conversion
+ext_modules = [Extension(name.split('.')[0].replace('/', '.'), sources=[name],
+                         language='c', include_dirs=[np.get_include()],
+                         extra_compile_args=['-O3'])
+               for name in glob.glob("gsroptim/*.pyx")]
+
 setup(name='gsroptim',
       version=VERSION,
       description=DESCRIPTION,
@@ -21,7 +31,10 @@ setup(name='gsroptim',
       maintainer_email=MAINTAINER_EMAIL,
       url=URL,
       download_url=DOWNLOAD_URL,
+            install_requires=['numpy>=1.12', 'scipy>=0.18.0',
+                        'matplotlib>=2.0.0', 'Cython>=0.26',
+                        'scikit-learn>=0.21', 'xarray'],
       packages=['gsroptim'],
-      ext_modules=cythonize("gsroptim/*.pyx"),
-      include_dirs=[np.get_include()]
+      cmdclass={'build_ext': build_ext},
+      ext_modules=ext_modules,
       )


### PR DESCRIPTION
Hi @EugeneNdiaye 

If we want to plug this package into benchopt, the package needs to install the requirements directly when `pip install -e .` is run

This PR:

- gets rid of `import cython` (failing if cython is not installed beforehand), 
- installs numpy via a "hack" before it is imported in `setup.py`, 
- adds `install_requires` argument which installs the packages if they are not present.

I have also added a Makefile copied from celer, so that I can `make clean`, `make install`, etc. 

ping @agramfort @tomamoral